### PR TITLE
fix: Resolve deprecation warning when using framer-motion component

### DIFF
--- a/components/common/AppWrapper.tsx
+++ b/components/common/AppWrapper.tsx
@@ -23,7 +23,7 @@ function	WithLayout(props: AppProps): ReactElement {
 				shouldUseNetworks={true}
 				shouldUseWallets={true} />
 			<div id={'app'} className={'mx-auto mb-0 flex w-full max-w-6xl flex-col pt-6 md:pt-0'}>
-				<AnimatePresence exitBeforeEnter>
+				<AnimatePresence mode={'wait'}>
 					<motion.div
 						key={router.asPath}
 						initial={'initial'}


### PR DESCRIPTION
## Description

I updated the `exitBeforeEnter` prop for  `<AnimatedPresence />`  to instead be `mode={'wait'}`. This was done following the instructions of a deprecation warning from framer-motion which appeared in the console when running the site in dev mode. It's my understanding that this new property is equivalent to the old one (docs link below). After the change the warning is no longer present, and I saw no visible difference to site functionality.

<img width="690" alt="AnimatedPresence" src="https://user-images.githubusercontent.com/95051992/186424974-c8cc539e-e5cd-4fe0-882c-aa638533a66a.png">




## Type of change

- [X] Other -Resolve console warning


## Change details

N/A


## Resources

[Framer Motion Docs (AnimatePresence mode)](https://www.framer.com/docs/animate-presence/###mode)
